### PR TITLE
Fix urls for queries with spaces

### DIFF
--- a/gh_inspector.gemspec
+++ b/gh_inspector.gemspec
@@ -9,16 +9,18 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Orta Therox', 'Felix Krause']
   spec.email         = ['orta.therox@gmail.com', 'gh_inspector@krausefx.com']
 
+  spec.license       = 'MIT'
   spec.summary       = 'Search through GitHub issues for your project for existing issues about a Ruby Error.'
+  spec.description   = spec.summary
+
   spec.homepage      = 'https://github.com/orta/gh_inspector'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'pry', '~> 0.6'
+  spec.add_development_dependency 'rubocop', '~> 0', '> 0'
 end

--- a/lib/gh_inspector/sidekick.rb
+++ b/lib/gh_inspector/sidekick.rb
@@ -77,7 +77,7 @@ module GhInspector
     # Converts a GitHub search JSON into a InspectionReport
     def parse_results(query, results)
       report = InspectionReport.new
-      report.url = "https://github.com/#{repo_owner}/#{repo_name}/search?q=#{query}&type=Issues&utf8=✓"
+      report.url = "https://github.com/#{repo_owner}/#{repo_name}/search?q=#{URI.escape(query)}&type=Issues&utf8=✓"
       report.query = query
       report.total_results = results['total_count']
       report.issues = results['items'].map { |item| Issue.new(item) }

--- a/lib/gh_inspector/version.rb
+++ b/lib/gh_inspector/version.rb
@@ -1,3 +1,3 @@
 module GhInspector
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/spec/inspector/evidence_spec.rb
+++ b/spec/inspector/evidence_spec.rb
@@ -12,10 +12,10 @@ describe GhInspector::Evidence do
 
   describe 'reaction to delegate calls' do
     before do
-      url = 'https://api.github.com/search/issues?q=Testing+repo:orta/my_repo'
+      url = 'https://api.github.com/search/issues?q=Testing%20OK+repo:orta/my_repo'
       json = JSON.parse File.read('spec/inspector/stubbed_example.json')
       allow(@subject).to receive(:get_api_results).with(url).and_return(json)
-      @report = @subject.search 'Testing', SilentEvidence.new
+      @report = @subject.search 'Testing OK', SilentEvidence.new
     end
 
     it 'handles a message about the start of a query' do
@@ -44,7 +44,7 @@ describe GhInspector::Evidence do
    https://github.com/CocoaPods/CocoaPods/issues/4345 [closed] [21 comments]
    2 weeks ago
 
-and 30 more at: https://github.com/orta/my_repo/search?q=Testing&type=Issues&utf8=✓
+and 30 more at: https://github.com/orta/my_repo/search?q=Testing%20OK&type=Issues&utf8=✓
 
 eos
     end
@@ -73,7 +73,7 @@ eos
    https://github.com/CocoaPods/CocoaPods/issues/4345 [closed] [21 comments]
    2 weeks ago
 
-and 30 more at: https://github.com/orta/my_repo/search?q=Testing&type=Issues&utf8=✓
+and 30 more at: https://github.com/orta/my_repo/search?q=Testing%20OK&type=Issues&utf8=✓
 
   eos
       end

--- a/spec/inspector/evidence_spec.rb
+++ b/spec/inspector/evidence_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe GhInspector::Evidence do
   before do
-    time = Time.new(2016, 05, 13)
+    time = Time.new(2016, 5, 13)
     allow(Time).to receive(:now).and_return time
 
     inspector = GhInspector::Inspector.new('orta', 'my_repo')

--- a/spec/inspector/sidekick_spec.rb
+++ b/spec/inspector/sidekick_spec.rb
@@ -14,7 +14,7 @@ describe GhInspector::Sidekick do
 
   describe 'when searching' do
     before do
-      url = 'https://api.github.com/search/issues?q=Testing+repo:orta/my_repo'
+      url = 'https://api.github.com/search/issues?q=Testing%20something+repo:orta/my_repo'
       json = JSON.parse File.read('spec/inspector/stubbed_example.json')
       allow(@subject).to receive(:get_api_results).with(url).and_return(json)
     end
@@ -24,15 +24,15 @@ describe GhInspector::Sidekick do
     end
 
     it 'works right with fixtured data' do
-      results = @subject.search 'Testing', @evidence
+      results = @subject.search 'Testing something', @evidence
 
-      expect(results.url).to eq "https://github.com/orta/my_repo/search?q=Testing&type=Issues&utf8=✓"
-      expect(results.query).to eq 'Testing'
+      expect(results.url).to eq "https://github.com/orta/my_repo/search?q=Testing%20something&type=Issues&utf8=✓"
+      expect(results.query).to eq 'Testing something'
       expect(results.total_results).to eq 33
     end
 
     it 'creates fully set up issues' do
-      results = @subject.search 'Testing', @evidence
+      results = @subject.search 'Testing something', @evidence
       issue = results.issues.first
 
       expect(issue.title).to eq 'Travis CI with Ruby 1.9.x fails for recent pull requests'


### PR DESCRIPTION
Fixes #10 - this is definitely the fault of gh_inspector.

Changed a bunch of specs to reflect spaces to ensure everything is 👍 