### PR TITLE
Print a message explaining how to quickly open links on macOS

### DIFF
--- a/lib/gh_inspector/evidence.rb
+++ b/lib/gh_inspector/evidence.rb
@@ -37,12 +37,15 @@ module GhInspector
         puts "and #{report.total_results - NUMBER_OF_ISSUES_INLINE} more at: #{report.url}"
         puts ""
       end
+
+      print_open_link_hint
     end
 
     # Called once the report has been recieved, but when there are no issues found.
     def inspector_recieved_empty_report(report, inspector)
       puts "Found no similar issues. To create a new issue, please visit:"
       puts "https://github.com/#{inspector.repo_owner}/#{inspector.repo_name}/issues/new"
+      print_open_link_hint(true)
     end
 
     # Called when there have been networking issues in creating the report.
@@ -50,6 +53,7 @@ module GhInspector
       puts "Could not access the GitHub API, you may have better luck via the website."
       puts "https://github.com/#{inspector.repo_owner}/#{inspector.repo_name}/search?q=#{query}&type=Issues&utf8=✓"
       puts "Error: #{error.name}"
+      print_open_link_hint(true)
     end
 
     private
@@ -59,6 +63,11 @@ module GhInspector
       puts "   #{issue.html_url} [#{issue.state}] [#{issue.comments} comment#{issue.comments == 1 ? '' : 's'}]"
       puts "   #{Time.parse(issue.updated_at).to_pretty}"
       puts ""
+    end
+
+    def print_open_link_hint(newline = false)
+      puts "" if newline
+      puts "You can ⌘ + double-click on links to open them directly in your browser. 🔗" if /darwin/ =~ RUBY_PLATFORM
     end
   end
 end

--- a/spec/inspector/evidence_spec.rb
+++ b/spec/inspector/evidence_spec.rb
@@ -31,7 +31,7 @@ describe GhInspector::Evidence do
       end
 
       @evidence.inspector_successfully_recieved_report(@report, @subject)
-      expect(message).to eq <<-eos
+      expect(message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
    https://github.com/CocoaPods/CocoaPods/issues/646 [closed] [8 comments]
    14 Nov 2012
@@ -47,6 +47,7 @@ describe GhInspector::Evidence do
 and 30 more at: https://github.com/orta/my_repo/search?q=Testing%20OK&type=Issues&utf8=✓
 
 eos
+      expect(message).to end_with "\nYou can ⌘ + double-click on links to open them directly in your browser. 🔗\n" if /darwin/ =~ RUBY_PLATFORM
     end
 
     describe '' do
@@ -60,7 +61,7 @@ eos
       it 'handles full results' do
         @evidence.inspector_successfully_recieved_report(@report, @subject)
 
-        expect(@message).to eq <<-eos
+        expect(@message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
    https://github.com/CocoaPods/CocoaPods/issues/646 [closed] [8 comments]
    14 Nov 2012
@@ -76,26 +77,29 @@ eos
 and 30 more at: https://github.com/orta/my_repo/search?q=Testing%20OK&type=Issues&utf8=✓
 
   eos
+        expect(@message).to end_with "\nYou can ⌘ + double-click on links to open them directly in your browser. 🔗\n" if /darwin/ =~ RUBY_PLATFORM
       end
 
       it 'handles less results differenly' do
         @report.issues = [@report.issues.first]
         @evidence.inspector_successfully_recieved_report(@report, @subject)
 
-        expect(@message).to eq <<-eos
+        expect(@message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
    https://github.com/CocoaPods/CocoaPods/issues/646 [closed] [8 comments]
    14 Nov 2012
 
 eos
+        expect(@message).to end_with "\nYou can ⌘ + double-click on links to open them directly in your browser. 🔗\n" if /darwin/ =~ RUBY_PLATFORM
       end
 
       it 'handles empty results' do
         @evidence.inspector_recieved_empty_report(@report, @subject)
-        expect(@message).to eq <<-eos
+        expect(@message).to start_with <<-eos
 Found no similar issues. To create a new issue, please visit:
 https://github.com/orta/my_repo/issues/new
   eos
+        expect(@message).to end_with "\nYou can ⌘ + double-click on links to open them directly in your browser. 🔗\n" if /darwin/ =~ RUBY_PLATFORM
       end
 
       it 'handles network errors' do
@@ -103,11 +107,12 @@ https://github.com/orta/my_repo/issues/new
         allow(error).to receive(:name).and_return("Network Error")
 
         @evidence.inspector_could_not_create_report(error, "query", @subject)
-        expect(@message).to eq <<-eos
+        expect(@message).to start_with <<-eos
 Could not access the GitHub API, you may have better luck via the website.
 https://github.com/orta/my_repo/search?q=query&type=Issues&utf8=✓
 Error: Network Error
   eos
+        expect(@message).to end_with "\nYou can ⌘ + double-click on links to open them directly in your browser. 🔗\n" if /darwin/ =~ RUBY_PLATFORM
       end
     end
   end


### PR DESCRIPTION
Because ⌘ + double-click is much faster than
1. double-click + drag
2. ⌘ + C
3. ⌘ + n × ⇥
4. ⌘ + T
5. ⌘ + V
6. ⏎