### PR TITLE
Autoload the sidekick libraries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,3 +121,7 @@ Style/ZeroLengthPredicate:
 
 Lint/UnusedMethodArgument:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### Master
 
 * Adds support for showing how to click on a link in terminal - 0xced
+* Moves require statements for JSON parsing, and URL loading inline inside the sidekick - orta
+
+  This comes because of trouble inside the Mac app for CocoaPods having a pretty unique Ruby setup, and it's helper 
+  process would crash when handling different parts of import system.
 
 ### 1.0.3
 

--- a/lib/gh_inspector/sidekick.rb
+++ b/lib/gh_inspector/sidekick.rb
@@ -1,3 +1,5 @@
+autoload :Net, 'net/http'
+autoload :URI, 'uri'
 
 module GhInspector
   # The Sidekick is the one who does all the real work.
@@ -15,9 +17,6 @@ module GhInspector
 
     # Searches for a query, with a UI delegate
     def search(query, delegate)
-      require "net/http"
-      require 'uri'
-
       validate_delegate(delegate)
 
       delegate.inspector_started_query(query, inspector)
@@ -49,6 +48,8 @@ module GhInspector
 
     private
 
+    autoload :JSON, 'json'
+
     # Generates a URL for the request
     def url_for_request(query, sort_by: nil, order: nil)
       url = "https://api.github.com/search/issues?q="
@@ -62,8 +63,6 @@ module GhInspector
 
     # Gets the search results
     def get_api_results(url)
-      require 'json'
-
       uri = URI.parse(url)
       puts "URL: #{url}" if self.verbose
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/gh_inspector/sidekick.rb
+++ b/lib/gh_inspector/sidekick.rb
@@ -1,5 +1,3 @@
-require "net/http"
-require 'uri'
 
 module GhInspector
   # The Sidekick is the one who does all the real work.
@@ -17,6 +15,9 @@ module GhInspector
 
     # Searches for a query, with a UI delegate
     def search(query, delegate)
+      require "net/http"
+      require 'uri'
+
       validate_delegate(delegate)
 
       delegate.inspector_started_query(query, inspector)
@@ -48,8 +49,6 @@ module GhInspector
 
     private
 
-    require 'json'
-
     # Generates a URL for the request
     def url_for_request(query, sort_by: nil, order: nil)
       url = "https://api.github.com/search/issues?q="
@@ -63,6 +62,8 @@ module GhInspector
 
     # Gets the search results
     def get_api_results(url)
+      require 'json'
+
       uri = URI.parse(url)
       puts "URL: #{url}" if self.verbose
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/gh_inspector/version.rb
+++ b/lib/gh_inspector/version.rb
@@ -1,3 +1,3 @@
 module GhInspector
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end

--- a/spec/inspector/sidekick_spec.rb
+++ b/spec/inspector/sidekick_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe GhInspector::Sidekick do
   before do


### PR DESCRIPTION
Been having issues with the CP mac app related to some of the system imports that gh_inspector brings in https://github.com/CocoaPods/CocoaPods-app/issues/376

This moves those imports to only happen during the code that needs them.