### PR TITLE
Fix typo in two methods' name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ inspector.search_query "Someone set us up the bomb", FastlaneUI.new
 Protocol for custom objects:
 
  - `inspector_started_query(query, inspector)` - Called just as the investigation has begun.
- - `inspector_successfully_recieved_report(report, inspector)` - Called once the inspector has received a report with more than one issue.
- - `inspector_recieved_empty_report(report, inspector)` - Called once the report has been received, but when there are no issues found.
+ - `inspector_successfully_received_report(report, inspector)` - Called once the inspector has received a report with more than one issue.
+ - `inspector_received_empty_report(report, inspector)` - Called once the report has been received, but when there are no issues found.
  - `inspector_could_not_create_report(error, query, inspector)` - Called when there have been networking issues in creating the report.
 
 

--- a/lib/gh_inspector/evidence.rb
+++ b/lib/gh_inspector/evidence.rb
@@ -29,8 +29,14 @@ module GhInspector
       puts ""
     end
 
-    # Called once the inspector has recieved a report with more than one issue.
+    # Deprecated: Please use `inspector_successfully_received_report` instead
     def inspector_successfully_recieved_report(report, inspector)
+      warn "[DEPRECATION] `inspector_successfully_recieved_report` is deprecated. Please use `inspector_successfully_received_report` instead."
+      inspector_successfully_received_report(report, inspector)
+    end
+
+    # Called once the inspector has received a report with more than one issue.
+    def inspector_successfully_received_report(report, inspector)
       report.issues[0..(NUMBER_OF_ISSUES_INLINE - 1)].each { |issue| print_issue_full(issue) }
 
       if report.issues.count > NUMBER_OF_ISSUES_INLINE
@@ -41,8 +47,14 @@ module GhInspector
       print_open_link_hint
     end
 
-    # Called once the report has been recieved, but when there are no issues found.
+    # Deprecated: Please use `inspector_received_empty_report` instead
     def inspector_recieved_empty_report(report, inspector)
+      warn "[DEPRECATION] `inspector_recieved_empty_report` is deprecated. Please use `inspector_received_empty_report` instead."
+      inspector_received_empty_report(report, inspector)
+    end
+
+    # Called once the report has been received, but when there are no issues found.
+    def inspector_received_empty_report(report, inspector)
       puts "Found no similar issues. To create a new issue, please visit:"
       puts "https://github.com/#{inspector.repo_owner}/#{inspector.repo_name}/issues/new"
       print_open_link_hint(true)

--- a/lib/gh_inspector/sidekick.rb
+++ b/lib/gh_inspector/sidekick.rb
@@ -34,9 +34,9 @@ module GhInspector
       # TODO: progress callback
 
       if report.issues.any?
-        delegate.inspector_successfully_recieved_report(report, inspector)
+        delegate.inspector_successfully_received_report(report, inspector)
       else
-        delegate.inspector_recieved_empty_report(report, inspector)
+        delegate.inspector_received_empty_report(report, inspector)
       end
 
       report

--- a/spec/inspector/evidence_spec.rb
+++ b/spec/inspector/evidence_spec.rb
@@ -30,7 +30,7 @@ describe GhInspector::Evidence do
         message << args.first + "\n"
       end
 
-      @evidence.inspector_successfully_recieved_report(@report, @subject)
+      @evidence.inspector_successfully_received_report(@report, @subject)
       expect(message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
    https://github.com/CocoaPods/CocoaPods/issues/646 [closed] [8 comments]
@@ -59,7 +59,7 @@ eos
       end
 
       it 'handles full results' do
-        @evidence.inspector_successfully_recieved_report(@report, @subject)
+        @evidence.inspector_successfully_received_report(@report, @subject)
 
         expect(@message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
@@ -82,7 +82,7 @@ and 30 more at: https://github.com/orta/my_repo/search?q=Testing%20OK&type=Issue
 
       it 'handles less results differenly' do
         @report.issues = [@report.issues.first]
-        @evidence.inspector_successfully_recieved_report(@report, @subject)
+        @evidence.inspector_successfully_received_report(@report, @subject)
 
         expect(@message).to start_with <<-eos
  - Travis CI with Ruby 1.9.x fails for recent pull requests
@@ -94,7 +94,7 @@ eos
       end
 
       it 'handles empty results' do
-        @evidence.inspector_recieved_empty_report(@report, @subject)
+        @evidence.inspector_received_empty_report(@report, @subject)
         expect(@message).to start_with <<-eos
 Found no similar issues. To create a new issue, please visit:
 https://github.com/orta/my_repo/issues/new

--- a/spec/inspector/sidekick_spec.rb
+++ b/spec/inspector/sidekick_spec.rb
@@ -68,7 +68,7 @@ describe GhInspector::Sidekick do
     it 'sends a report if successful and there are issues' do
       allow(@subject).to receive(:get_api_results).and_return(@json)
 
-      expect(@evidence).to receive(:inspector_successfully_recieved_report)
+      expect(@evidence).to receive(:inspector_successfully_received_report)
       @subject.search 'Testing', @evidence
     end
 
@@ -76,7 +76,7 @@ describe GhInspector::Sidekick do
       @json['items'] = []
       allow(@subject).to receive(:get_api_results).and_return(@json)
 
-      expect(@evidence).to receive(:inspector_recieved_empty_report)
+      expect(@evidence).to receive(:inspector_received_empty_report)
       @subject.search 'Testing', @evidence
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,10 @@ class SilentEvidence
   def inspector_is_still_investigating(_query, _inspector); end
 
   def inspector_successfully_recieved_report(_report, _inspector); end
+  def inspector_successfully_received_report(_report, _inspector); end
 
   def inspector_recieved_empty_report(_report, _inspector); end
+  def inspector_received_empty_report(_report, _inspector); end
 
   def inspector_could_not_create_report(_error, _query, _inspector); end
 end


### PR DESCRIPTION
Fixes #19.
Related to https://github.com/fastlane/fastlane/pull/10837.

Let me know if this is the correct way to deprecate methods in ruby.
I didn't actually test this because I'm not accustomed with this library, but I ran the existing tests.