### PR TITLE
Ignore deprecated methods when validating delegates

### DIFF
--- a/lib/gh_inspector/sidekick.rb
+++ b/lib/gh_inspector/sidekick.rb
@@ -86,9 +86,13 @@ module GhInspector
 
     def validate_delegate(delegate)
       e = Evidence.new
+      deprecated_delegates = [
+        :inspector_successfully_recieved_report,
+        :inspector_recieved_empty_report
+      ]
       protocol = e.public_methods false
       protocol.each do |m|
-        raise "#{delegate} does not handle #{m}" unless delegate.methods.include? m
+        raise "#{delegate} does not handle #{m}" unless delegate.methods.include?(m) || deprecated_delegates.include?(m)
       end
     end
   end

--- a/spec/inspector/sidekick_spec.rb
+++ b/spec/inspector/sidekick_spec.rb
@@ -5,6 +5,7 @@ describe GhInspector::Sidekick do
     @inspector = GhInspector::Inspector.new('orta', 'my_repo')
     @subject = GhInspector::Sidekick.new @inspector, 'orta', 'my_repo'
     @evidence = SilentEvidence.new
+    @new_evidence = NewSilentEvidence.new
   end
 
   it 'keeps track of user / repo' do
@@ -68,7 +69,7 @@ describe GhInspector::Sidekick do
     it 'sends a report if successful and there are issues' do
       allow(@subject).to receive(:get_api_results).and_return(@json)
 
-      expect(@evidence).to receive(:inspector_successfully_received_report)
+      expect(@evidence).to receive(:inspector_successfully_recieved_report)
       @subject.search 'Testing', @evidence
     end
 
@@ -76,8 +77,23 @@ describe GhInspector::Sidekick do
       @json['items'] = []
       allow(@subject).to receive(:get_api_results).and_return(@json)
 
-      expect(@evidence).to receive(:inspector_received_empty_report)
+      expect(@evidence).to receive(:inspector_recieved_empty_report)
       @subject.search 'Testing', @evidence
+    end
+
+    it 'sends a report if successful and there are issues for delegate with new methods' do
+      allow(@subject).to receive(:get_api_results).and_return(@json)
+
+      expect(@new_evidence).to receive(:inspector_successfully_received_report)
+      @subject.search 'Testing', @new_evidence
+    end
+
+    it 'sends a message about empty reports for delegate with new methods' do
+      @json['items'] = []
+      allow(@subject).to receive(:get_api_results).and_return(@json)
+
+      expect(@new_evidence).to receive(:inspector_received_empty_report)
+      @subject.search 'Testing', @new_evidence
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,7 @@ class SilentEvidence
 
   def inspector_is_still_investigating(_query, _inspector); end
 
-  def inspector_successfully_recieved_report(_report, _inspector); end
-
   def inspector_successfully_received_report(_report, _inspector); end
-
-  def inspector_recieved_empty_report(_report, _inspector); end
 
   def inspector_received_empty_report(_report, _inspector); end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,18 @@ class SilentEvidence
 
   def inspector_is_still_investigating(_query, _inspector); end
 
+  def inspector_successfully_recieved_report(_report, _inspector); end
+
+  def inspector_recieved_empty_report(_report, _inspector); end
+
+  def inspector_could_not_create_report(_error, _query, _inspector); end
+end
+
+class NewSilentEvidence
+  def inspector_started_query(_query, _inspector); end
+
+  def inspector_is_still_investigating(_query, _inspector); end
+
   def inspector_successfully_received_report(_report, _inspector); end
 
   def inspector_received_empty_report(_report, _inspector); end


### PR DESCRIPTION
With the previous PR, you had to implement both the deprecated and the new methods in order for the validation to pass, which was obviously incorrect.

With this, it passes if a deprecated method is not implemented.

Though, I'm pretty sure that an additional check is needed here:

https://github.com/orta/gh_inspector/pull/20/files#diff-c65f1a97c8c4cb2204bde822b32bc755R37